### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
         dotnet --list-runtimes
       displayName: install .NET $(DotNetVersion)
     - script: |
-        dotnet publish HelloAndroid\HelloAndroid.csproj -c Debug
-        dotnet publish HelloAndroid\HelloAndroid.csproj -c Release
-        dotnet publish HelloForms.Android\HelloForms.Android.csproj -c Debug
-        dotnet publish HelloForms.Android\HelloForms.Android.csproj -c Release
+        dotnet publish HelloAndroid/HelloAndroid.csproj -c Debug
+        dotnet publish HelloAndroid/HelloAndroid.csproj -c Release
+        dotnet publish HelloForms.Android/HelloForms.Android.csproj -c Debug
+        dotnet publish HelloForms.Android/HelloForms.Android.csproj -c Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
         $ErrorActionPreference = 'Stop'
         $ProgressPreference = 'SilentlyContinue'
         Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
-        & ./dotnet-install.ps1 -Version $(DotNetVersion)
+        & .\dotnet-install.ps1 -Version $(DotNetVersion) -InstallDir "$env:ProgramFiles\dotnet\"
       displayName: install .NET $(DotNetVersion)
     - script: |
         dotnet publish HelloAndroid\HelloAndroid.csproj -c Debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
         dotnet publish HelloForms.Android\HelloForms.Android.csproj -c Release
 - job: mac
   pool:
-    name: Hosted Mac Internal
+    name: Hosted macOS
   steps:
     - bash: |
         curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh
@@ -33,5 +33,7 @@ jobs:
         dotnet --list-runtimes
       displayName: install .NET $(DotNetVersion)
     - script: |
-        dotnet publish net5-samples.sln -c Debug
-        dotnet publish net5-samples.sln -c Release
+        dotnet publish HelloAndroid\HelloAndroid.csproj -c Debug
+        dotnet publish HelloAndroid\HelloAndroid.csproj -c Release
+        dotnet publish HelloForms.Android\HelloForms.Android.csproj -c Debug
+        dotnet publish HelloForms.Android\HelloForms.Android.csproj -c Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
 jobs:
 - job: windows
   pool:
-    name: Hosted Windows 2019 with VS2019
+    name: windows-latest
   steps:
     - powershell: |
         $ErrorActionPreference = 'Stop'
@@ -25,7 +25,7 @@ jobs:
         dotnet publish HelloForms.Android\HelloForms.Android.csproj -c Release
 - job: mac
   pool:
-    name: Hosted macOS
+    name: macOS-latest
   steps:
     - bash: |
         curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,8 @@ jobs:
   steps:
     - bash: |
         curl https://dot.net/v1/dotnet-install.sh > dotnet-install.sh
-        sh dotnet-install.sh --version $(DotNetVersion) --install-dir ~/.dotnet/ --verbose
+        chmod +x dotnet-install.sh
+        ./dotnet-install.sh --version $(DotNetVersion) --install-dir ~/.dotnet/ --verbose
         dotnet --list-runtimes
       displayName: install .NET $(DotNetVersion)
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,9 +28,8 @@ jobs:
     name: Hosted macOS
   steps:
     - bash: |
-        curl https://dot.net/v1/dotnet-install.sh > dotnet-install.sh
-        chmod +x dotnet-install.sh
-        ./dotnet-install.sh --version $(DotNetVersion) --install-dir ~/.dotnet/ --verbose
+        curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh
+        sh dotnet-install.sh --version $(DotNetVersion) --install-dir ~/.dotnet/ --verbose
         dotnet --list-runtimes
       displayName: install .NET $(DotNetVersion)
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,5 @@ jobs:
         dotnet --list-runtimes
       displayName: install .NET $(DotNetVersion)
     - script: |
-        dotnet publish HelloAndroid/HelloAndroid.csproj -c Debug
-        dotnet publish HelloAndroid/HelloAndroid.csproj -c Release
-        dotnet publish HelloForms.Android/HelloForms.Android.csproj -c Debug
-        dotnet publish HelloForms.Android/HelloForms.Android.csproj -c Release
+        dotnet publish net5-samples.sln -c Debug
+        dotnet publish net5-samples.sln -c Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,9 +27,9 @@ jobs:
   pool:
     name: Hosted macOS
   steps:
-    - script: |
+    - bash: |
         curl https://dot.net/v1/dotnet-install.sh > dotnet-install.sh
-        sh dotnet-install.sh --version $(DotNetVersion) --install-dir /usr/local/share/dotnet/
+        sh dotnet-install.sh --version $(DotNetVersion) --install-dir ~/.dotnet/
         dotnet --list-runtimes
       displayName: install .NET $(DotNetVersion)
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
 jobs:
 - job: windows
   pool:
-    name: windows-latest
+    name: Hosted Windows 2019 with VS2019
   steps:
     - powershell: |
         $ErrorActionPreference = 'Stop'
@@ -25,7 +25,7 @@ jobs:
         dotnet publish HelloForms.Android\HelloForms.Android.csproj -c Release
 - job: mac
   pool:
-    name: macOS-latest
+    name: Hosted Mac Internal
   steps:
     - bash: |
         curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
         $ErrorActionPreference = 'Stop'
         $ProgressPreference = 'SilentlyContinue'
         Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
-        & .\dotnet-install.ps1 -Version $(DotNetVersion) -InstallDir "$env:ProgramFiles\dotnet\"
+        & .\dotnet-install.ps1 -Version $(DotNetVersion) -InstallDir "$env:ProgramFiles\dotnet\" -Verbose
         & dotnet --list-runtimes
       displayName: install .NET $(DotNetVersion)
     - script: |
@@ -29,7 +29,7 @@ jobs:
   steps:
     - bash: |
         curl https://dot.net/v1/dotnet-install.sh > dotnet-install.sh
-        sh dotnet-install.sh --version $(DotNetVersion) --install-dir ~/.dotnet/
+        sh dotnet-install.sh --version $(DotNetVersion) --install-dir ~/.dotnet/ --verbose
         dotnet --list-runtimes
       displayName: install .NET $(DotNetVersion)
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,33 @@
+# https://aka.ms/yaml
+
+trigger:
+- master
+
+variables:
+  DotNetVersion: 5.0.100-preview.3.20216.6
+
+jobs:
+- job: windows
+  pool:
+    name: Hosted Windows 2019 with VS2019
+  steps:
+    - task: UseDotNet@2
+      displayName: install .NET $(DotNetVersion)
+      inputs:
+        version: $(DotNetVersion)
+    - script: |
+        dotnet publish HelloAndroid\HelloAndroid.csproj -c Debug
+        dotnet publish HelloAndroid\HelloAndroid.csproj -c Release
+        dotnet publish HelloForms.Android\HelloForms.Android.csproj -c Debug
+        dotnet publish HelloForms.Android\HelloForms.Android.csproj -c Release
+- job: mac
+  pool:
+    name: Hosted macOS
+  steps:
+    - task: UseDotNet@2
+      displayName: install .NET $(DotNetVersion)
+      inputs:
+        version: $(DotNetVersion)
+    - script: |
+        dotnet publish net5-samples.sln -c Debug
+        dotnet publish net5-samples.sln -c Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,11 +26,9 @@ jobs:
   pool:
     name: Hosted macOS
   steps:
-    - powershell: |
-        $ErrorActionPreference = 'Stop'
-        $ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
-        & ./dotnet-install.ps1 -Version $(DotNetVersion)
+    - script: |
+        curl https://dot.net/v1/dotnet-install.sh > dotnet-install.sh
+        sh dotnet-install.sh --version $(DotNetVersion)
       displayName: install .NET $(DotNetVersion)
     - script: |
         dotnet publish net5-samples.sln -c Debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
   steps:
     - script: |
         curl https://dot.net/v1/dotnet-install.sh > dotnet-install.sh
-        sh dotnet-install.sh --version $(DotNetVersion)
+        sh dotnet-install.sh --version $(DotNetVersion) --install-dir /usr/local/share/dotnet/
       displayName: install .NET $(DotNetVersion)
     - script: |
         dotnet publish net5-samples.sln -c Debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,7 @@ jobs:
         $ProgressPreference = 'SilentlyContinue'
         Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
         & .\dotnet-install.ps1 -Version $(DotNetVersion) -InstallDir "$env:ProgramFiles\dotnet\"
+        & dotnet --list-runtimes
       displayName: install .NET $(DotNetVersion)
     - script: |
         dotnet publish HelloAndroid\HelloAndroid.csproj -c Debug
@@ -29,6 +30,7 @@ jobs:
     - script: |
         curl https://dot.net/v1/dotnet-install.sh > dotnet-install.sh
         sh dotnet-install.sh --version $(DotNetVersion) --install-dir /usr/local/share/dotnet/
+        dotnet --list-runtimes
       displayName: install .NET $(DotNetVersion)
     - script: |
         dotnet publish net5-samples.sln -c Debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,17 +4,19 @@ trigger:
 - master
 
 variables:
-  DotNetVersion: 5.0.100-preview.3.20216.6
+  DotNetVersion: 5.0.100-preview.4.20227.14
 
 jobs:
 - job: windows
   pool:
     name: Hosted Windows 2019 with VS2019
   steps:
-    - task: UseDotNet@2
+    - powershell: |
+        $ErrorActionPreference = 'Stop'
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
+        & ./dotnet-install.ps1 -Version $(DotNetVersion)
       displayName: install .NET $(DotNetVersion)
-      inputs:
-        version: $(DotNetVersion)
     - script: |
         dotnet publish HelloAndroid\HelloAndroid.csproj -c Debug
         dotnet publish HelloAndroid\HelloAndroid.csproj -c Release
@@ -24,10 +26,12 @@ jobs:
   pool:
     name: Hosted macOS
   steps:
-    - task: UseDotNet@2
+    - powershell: |
+        $ErrorActionPreference = 'Stop'
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
+        & ./dotnet-install.ps1 -Version $(DotNetVersion)
       displayName: install .NET $(DotNetVersion)
-      inputs:
-        version: $(DotNetVersion)
     - script: |
         dotnet publish net5-samples.sln -c Debug
         dotnet publish net5-samples.sln -c Release

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "msbuild-sdks": {
-            "Microsoft.iOS.Sdk": "13.21.1-alpha.120",
+            "Microsoft.iOS.Sdk": "13.21.1-alpha.139",
             "Microsoft.Android.Sdk": "10.4.99.37"
     }
 }


### PR DESCRIPTION
Now that this repo is in a working state, I think it's worth adding something simple here to make sure these samples continue to build.

Using: https://docs.microsoft.com/en-us/dotnet/core/tools/using-ci-with-cli

I've been able to install any build of .NET 5 found here:

https://github.com/dotnet/installer#installers-and-binaries

This builds iOS and Android on macOS and just Android on Windows.