### PR TITLE
Add few more package references

### DIFF
--- a/HelloForms.Android/HelloForms.Android.csproj
+++ b/HelloForms.Android/HelloForms.Android.csproj
@@ -45,5 +45,17 @@
     <PackageReference Include="Xamarin.AndroidX.VersionedParcelable" Version="1.1.0" />
     <PackageReference Include="Xamarin.AndroidX.ViewPager" Version="1.0.0" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.0.0" />
+    <!--
+      add few more packages to bring missing dependencies while linking
+      it is probably same issue as here: https://github.com/mono/linker/issues/1139
+      these should not be needed once we have the AndroidX packages targetting net5
+    -->
+    <PackageReference Include="System.CodeDom" Version="5.0.0-preview.3.20214.6" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="5.0.0-preview.3.20214.6" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="5.0.0-preview.3.20214.6" />
+    <PackageReference Include="System.IO.Ports" Version="5.0.0-preview.3.20214.6" />
+    <PackageReference Include="System.Security.Permissions" Version="5.0.0-preview.3.20214.6" />
+    <PackageReference Include="System.Threading.AccessControl" Version="5.0.0-preview.3.20214.6" />
+    <PackageReference Include="Xamarin.Google.Guava.ListenableFuture" Version="1.0.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
To make it build with ILLink enabled. We should not need these once
we have AndroidX targeting net5